### PR TITLE
Added property to change iOS MapView tile overlay

### DIFF
--- a/Libraries/Components/MapView/MapView.js
+++ b/Libraries/Components/MapView/MapView.js
@@ -126,6 +126,17 @@ const MapView = React.createClass({
     ]),
 
     /**
+     * The tileOverlay URL template to use instead of the default tiles from Apple Maps, for use with MKTileOverlay
+     *
+     *  URL template is a string where the substrings "{x}", "{y}", "{z}", and "{scale}"
+     *  are replaced with values from a tile path to create a URL to load.
+     *  For example: http://server/path?x={x}&y={y}&z={z}&scale={scale}.
+     *
+     * @platform ios
+     */
+    tileOverlayURLTemplate: React.PropTypes.string,
+
+    /**
      * The region to be displayed by the map.
      *
      * The region is defined by the center coordinates and the span of

--- a/React/Views/RCTMap.h
+++ b/React/Views/RCTMap.h
@@ -27,6 +27,7 @@ RCT_EXTERN const CGFloat RCTMapZoomBoundBuffer;
 @property (nonatomic, strong) NSTimer *regionChangeObserveTimer;
 @property (nonatomic, copy) NSArray<NSString *> *annotationIDs;
 @property (nonatomic, copy) NSArray<NSString *> *overlayIDs;
+@property (nonatomic, copy) NSString *tileOverlayURLTemplate;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onPress;

--- a/React/Views/RCTMapManager.m
+++ b/React/Views/RCTMapManager.m
@@ -106,6 +106,17 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
   [view setRegion:json ? [RCTConvert MKCoordinateRegion:json] : defaultView.region animated:YES];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(tileOverlayURLTemplate, NSString, RCTMap)
+{
+  if (json != nil) {
+    MKTileOverlay *overlay = [[MKTileOverlay alloc] initWithURLTemplate:json];
+    overlay.canReplaceMapContent = YES;
+    [view addOverlay:overlay level:MKOverlayLevelAboveLabels];
+  } else {
+    view = defaultView;
+  }
+}
+
 - (NSDictionary<NSString *, id> *)constantsToExport
 {
   NSString *red, *green, *purple;
@@ -313,10 +324,12 @@ RCT_CUSTOM_VIEW_PROPERTY(region, MKCoordinateRegion, RCTMap)
 {
   if ([overlay isKindOfClass:[RCTMapOverlay class]]) {
     MKPolylineRenderer *polylineRenderer =
-      [[MKPolylineRenderer alloc] initWithPolyline:overlay];
-    polylineRenderer.strokeColor = overlay.strokeColor;
-    polylineRenderer.lineWidth = overlay.lineWidth;
+    [[MKPolylineRenderer alloc] initWithPolyline:overlay];
+    polylineRenderer.strokeColor = ((RCTMapOverlay *)overlay).strokeColor;
+    polylineRenderer.lineWidth = ((RCTMapOverlay *)overlay).lineWidth;
     return polylineRenderer;
+  } else if ([overlay isKindOfClass:[MKTileOverlay class]]) {
+    return [[MKTileOverlayRenderer alloc] initWithTileOverlay:((MKTileOverlay *)overlay)];
   } else {
     return nil;
   }


### PR DESCRIPTION
This pull request will allow iOS mapViews to change the tile overlay source from Apple Maps to other sources, such as OpenStreetMaps, by setting the `tileOverlayURLTemplate` prop 

Example: 

```
  <MapView tileOverlayURLTemplate={"http://tile.openstreetmap.org/{z}/{x}/{y}.png"}
```
